### PR TITLE
Added: Simple disable file for Windows 10

### DIFF
--- a/ps1/simple_disable.ps1
+++ b/ps1/simple_disable.ps1
@@ -1,0 +1,18 @@
+# For Windows; place this file in the same directory as adb.exe
+.\adb.exe devices
+
+.\adb.exe shell pm disable-user com.google.android.youtube
+.\adb.exe shell pm disable-user com.google.android.googlequicksearchbox
+.\adb.exe shell pm disable-user com.google.android.apps.maps
+.\adb.exe shell pm disable-user com.google.android.gm
+.\adb.exe shell pm disable-user com.google.android.videos
+.\adb.exe shell pm disable-user com.android.chrome
+.\adb.exe shell pm disable-user com.google.android.music
+.\adb.exe shell pm disable-user com.google.android.apps.docs
+.\adb.exe shell pm disable-user com.sec.spp.push
+.\adb.exe shell pm disable-user com.sec.android.app.myfiles
+.\adb.exe shell pm disable-user com.sec.android.app.wallpaperchooser
+.\adb.exe shell pm disable-user com.sec.android.gallery3d
+.\adb.exe shell pm disable-user com.sec.android.mimage.photoretouching
+.\adb.exe shell pm disable-user com.sec.android.app.clockpackage
+.\adb.exe shell pm disable-user com.spotify.music


### PR DESCRIPTION
This script is a condensed version of the other two. It implies the user already has downloaded platform-services. All the user will have to do is place the simple_disable.ps1 script in the directory with adb. Some versions of Windows require the .\adb.exe. It also eliminates the need for adding adb to the systems path.